### PR TITLE
Remove minor party key at bottom of data

### DIFF
--- a/r-packages/voterregus/data-raw/ct/nov15re.csv
+++ b/r-packages/voterregus/data-raw/ct/nov15re.csv
@@ -184,26 +184,3 @@ Woodbury ,Litchfield ,5 ,"2392 59 2,451 ","1541 57 1,598 ",194 ,6 ,200 G IT L,26
 Town ,County ,C D ,Active Inactive Total ,Active Inactive Total ,Active ,Inactive ,Total M Notes ,Active ,Inactive Total ,"",Active ,Inactive ,Totals
 Woodstock ,Windham ,2 ,"1532 117 1,649 ","1250 130 1,380 ",97 ,12 ,109 G IT L,1938 ,"274 2,212 ","","4,817 ",533 ,"5,350"
 Totals ,"","","400,216 29,085 429,301 ","703,851 73,035 776,886 ","20,610 ","1,883 ","22,493 ","798,426 ","102,273 900,699 ","","1,923,103 ","206,276 ","2,129,379"
-"",Minor Party Key
-Party Key ,Party Name
-ABP ,A Brookfield Party
-C ,Concerned Citizen
-CT ,Connecticut for Lieberman
-CHA ,Chatham Party
-SWC ,South Windsor Citizens
-SGP ,Spring Glen Party
-FS ,Friends of Saybrook
-G ,Green Party
-I ,Independence
-IT ,Independent
-L ,Libertarian
-PRO ,Pro Bethel
-ETP ,Enfield Taxpayers
-WF ,Working Families
-RF ,Reform Party
-IM ,Independence for Montville
-OT ,Orange Taxpayers
-NC ,Norwich for Change
-MIP ,Milford Independent
-BF ,Better Future Party
-SP ,A Sentinel Party


### PR DESCRIPTION
PDF included a key for minor parties (aligning to the letters in Minor Parties Notes). Include this elsewhere in the repo so it's not part of the csv?