### PR TITLE
Append City or County to the four that distinguish

### DIFF
--- a/r-packages/uselections/R/va.R
+++ b/r-packages/uselections/R/va.R
@@ -9,8 +9,10 @@ loadVirginia <- function() {
   df <- read_csv("data-raw/va/Registrant_Count_By_Locality.csv", col_names=c('X1','X2'), skip=1, col_types='c____n__________________') %>%
     mutate(Year = 2016, Month = 11) %>% # Hardcode until we add historical data
     mutate(CountyName=trimws(gsub(x=X1, pattern="Locality: [0-9]+ ([ A-Z&]+) COUNTY", replacement="\\1"))) %>%
+    mutate(CountyName=ifelse(CountyName %in% c('FAIRFAX','FRANKLIN','ROANOKE','RICHMOND'),paste0(CountyName,' COUNTY'),CountyName)) %>%
     mutate(CountyName=trimws(gsub(x=CountyName, pattern="Locality: [0-9]+ ([ A-Z&]+) CITY", replacement="\\1"))) %>%
     mutate(CountyName=ifelse(CountyName=='KING & QUEEN', 'KING AND QUEEN', CountyName)) %>%
+    mutate(CountyName=ifelse(CountyName %in% c('FAIRFAX','FRANKLIN','ROANOKE','RICHMOND'),paste0(CountyName,' CITY'),CountyName)) %>%
     mutate(D=NA, G=NA, L=NA, R=NA, O=NA, N=X2) %>%
     select(CountyName, D, G, L, R, N, O, Year, Month) %>%
     mutate_each("as.integer", -CountyName) %>%


### PR DESCRIPTION
Fairfax, Franklin, Roanoke, and Richmond all have both City and County listed. Adding the distinction to CountyName for clarity, though it is already accounted for in the FIPS code.